### PR TITLE
mempool: Add post-dated tx to orphan pool even allowOrphan is false.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1083,23 +1083,9 @@ func (mp *TxPool) ProcessTransaction(tx *btcutil.Tx, allowOrphan, rateLimit bool
 		return acceptedTxs, nil
 	}
 
-	// TODO : Add additional comments
-	// This needs to be called before processing orphan transactions
-	// because coincase tx which is the only input of a post-dated tx is not in mempool,
-	// it will be count as orphan tx
-	txPd, err := mp.maybeAddPostDated(tx)
-	if err != nil {
-		return nil, err
-	}
-
-	if txPd != nil {
-		acceptedTxs := []*TxDesc{txPd}
-		return acceptedTxs, nil
-	}
-
 	// The transaction is an orphan (has inputs missing).  Reject
 	// it if the flag to allow orphans is not set.
-	if !allowOrphan {
+	if tx.MsgTx().Version != wire.PostDatedTxVersion && !allowOrphan {
 		// Only use the first missing parent transaction in
 		// the error message.
 		//
@@ -1118,21 +1104,6 @@ func (mp *TxPool) ProcessTransaction(tx *btcutil.Tx, allowOrphan, rateLimit bool
 	// Potentially add the orphan transaction to the orphan pool.
 	err = mp.maybeAddOrphan(tx, tag)
 	return nil, err
-}
-
-func (mp *TxPool) maybeAddPostDated(tx *btcutil.Tx) (*TxDesc, error) {
-	// Check if it is post-dated tx
-	if tx.MsgTx().Version != 3 {
-		return nil, nil
-	}
-
-	//txHash := tx.Hash()
-
-	// Some checks have already done inside 'maybeAcceptTransaction' method until
-	// missing parents check. 'maybeAcceptTransaction' return since coincase tx
-	// isn't exist in mempool or blockchain. Rest of the check need to happen in here
-
-	return nil, nil
 }
 
 func IsPostDated(tx *btcutil.Tx) bool {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3352,6 +3352,11 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 	if len(acceptedTxs) == 0 || !acceptedTxs[0].Tx.Hash().IsEqual(tx.Hash()) {
 		s.cfg.TxMemPool.RemoveTransaction(tx, true)
 
+		// It is a post dated tx and it have been added to orphan pool
+		if tx.MsgTx().Version == wire.PostDatedTxVersion {
+			return tx.Hash().String(), nil
+		}
+
 		errStr := fmt.Sprintf("transaction %v is not in accepted list",
 			tx.Hash())
 		return nil, internalRPCError(errStr, "")


### PR DESCRIPTION
rpcserver: Return hash of post-dated tx that added to orphan pool